### PR TITLE
separates logEntry and commits in logEntry model

### DIFF
--- a/src/models/magitLog.ts
+++ b/src/models/magitLog.ts
@@ -1,6 +1,6 @@
-import { MagitLogCommit } from './magitLogCommit';
+import { MagitLogEntry } from './magitLogCommit';
 
 export interface MagitLog {
-  commits: MagitLogCommit[];
+  entries: MagitLogEntry[];
   revName: string;
 }

--- a/src/models/magitLogCommit.ts
+++ b/src/models/magitLogCommit.ts
@@ -1,11 +1,9 @@
 import { Commit } from '../typings/git';
 
-
-export interface MagitLogCommit extends Commit {
+export interface MagitLogEntry {
+  commit: Commit;
   graph: string[] | undefined;
-  hash: string;
   refs: string | undefined;
   author: string;
   time: Date;
-  message: string;
 }

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -2,7 +2,7 @@ import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
 import { Uri } from 'vscode';
 import * as Constants from '../common/constants';
 import { MagitLog } from '../models/magitLog';
-import { MagitLogCommit } from '../models/magitLogCommit';
+import { MagitLogEntry } from '../models/magitLogCommit';
 import { MagitRepository } from '../models/magitRepository';
 import { MagitState } from '../models/magitState';
 import GitTextUtils from '../utils/gitTextUtils';
@@ -19,7 +19,7 @@ export default class LogView extends DocumentView {
 
     this.subViews = [
       new TextView(`Commits in ${log.revName}`),
-      ...log.commits.map(commit => new CommitLongFormItemView(commit)),
+      ...log.entries.map(entry => new CommitLongFormItemView(entry)),
     ];
   }
 
@@ -33,21 +33,21 @@ export default class LogView extends DocumentView {
 
 export class CommitLongFormItemView extends CommitItemView {
 
-  constructor(public commit: MagitLogCommit) {
-    super(commit);
-    const timeDistance = formatDistanceToNowStrict(commit.time);
-    const hash = `${GitTextUtils.shortHash(commit.hash)} `;
-    const graph = commit.graph?.[0] ?? '';
-    const refs = commit.refs ? `(${commit.refs}) ` : '';
-    const msg = GitTextUtils.shortCommitMessage(commit.message);
+  constructor(public logEntry: MagitLogEntry) {
+    super(logEntry.commit);
+    const timeDistance = formatDistanceToNowStrict(logEntry.time);
+    const hash = `${GitTextUtils.shortHash(logEntry.commit.hash)} `;
+    const graph = logEntry.graph?.[0] ?? '';
+    const refs = logEntry.refs ? `(${logEntry.refs}) ` : '';
+    const msg = GitTextUtils.shortCommitMessage(logEntry.commit.message);
     this.textContent = truncateText(`${hash}${graph}${refs}${msg}`, 69, 70) +
-      truncateText(commit.author, 17, 18) +
+      truncateText(logEntry.author, 17, 18) +
       timeDistance;
 
     // Add the rest of the graph for this commit
-    if (commit.graph) {
-      for (let i = 1; i < commit.graph.length; i++) {
-        const g = commit.graph[i];
+    if (logEntry.graph) {
+      for (let i = 1; i < logEntry.graph.length; i++) {
+        const g = logEntry.graph[i];
         const emptyHashSpace = ' '.repeat(8);
         this.textContent += `\n${emptyHashSpace}${g}`;
       }


### PR DESCRIPTION
A couple of remarks about the model.
I think you're doing too much at once here and it becomes a bit diffuse.
So I've come up with a suggestion for splitting LogEntry and Commit, such that a LogEntry has a Commit instead of being one.

A note about not using classes:
When it comes to the models I use interface more as a struct or type. Ideally they should all be readonly as well. I've done a sloppy job with that so far though, and the fact that I extend the model of `extension/git` complicates things, and leads to the annoying problem of `authorEmail` and `parents`.
So really, it's nothing on you, it's the shortcuts I've taken to quickly make this extension work.
And thanks again for helping, I've done some testing and it looks and works great. 😃 

**Full ownership of the entire model is a goal further down the line.**

In general I'm going for more of a functional style than OO. (I realize this might not be clear 🐱 )
The view parts use classes and some OO patterns because it think it fits the problem well, but they don't keep that much state and their render functions are almost pure.
